### PR TITLE
Fix failing legacy/test_pl_locale.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    coderay (1.1.0)
     coveralls (0.8.1)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -20,9 +21,14 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.2)
+    method_source (0.8.2)
     mime-types (2.5)
     netrc (0.10.3)
     power_assert (0.2.3)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -33,6 +39,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     test-unit (3.0.9)
@@ -50,5 +57,6 @@ DEPENDENCIES
   bundler (~> 1.7)
   coveralls
   factory-helper!
+  pry
   rake
   test-unit

--- a/factory-helper.gemspec
+++ b/factory-helper.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "pry"
   spec.add_runtime_dependency "i18n", "~> 0.7"
   spec.add_development_dependency "coveralls"
 end

--- a/test/legacy/test_pl_locale.rb
+++ b/test/legacy/test_pl_locale.rb
@@ -5,21 +5,21 @@ class TestFakerPlLocale < Test::Unit::TestCase
   def setup
     @phone_prefixes = %w{12 13 14 15 16 17 18 22 23 24 25 29 32 33 34 41 42 43 44 46 48 52 54 55 56 58 59 61 62 63 65 67 68 71 74 75 76 77 81 82 83 84 85 86 87 89 91 94 95}.sort
     @cell_prefixes = %w{50 51 53 57 60 66 69 72 73 78 79 88}.sort
-    @previous_locale = FactoryHelper::Config.locale
-    #FactoryHelper::Config.locale = :pl
+    FactoryHelper::Config.locale = :pl
   end
 
   def teardown
-    #FactoryHelper::Config.locale = @previous_locale
+    FactoryHelper::Config.locale = nil
   end
 
   def test_faker_pl_phone_number
-    #TODO: this 999 is probably causing the intermittant failures
+    #TODO: this 999 is probably causing the intermittent failures
     prefixes = (0..999).map { Faker::PhoneNumber.phone_number[0,2] }.uniq.sort
     assert_equal @phone_prefixes, prefixes
   end
 
   def test_pl_cell_phone
+    #TODO: this 999 is probably causing the intermittent failures
     prefixes = (0..999).map { Faker::PhoneNumber.cell_phone[0,2] }.uniq.sort
     assert_equal @cell_prefixes, prefixes
   end

--- a/test/test_pl_locale.rb
+++ b/test/test_pl_locale.rb
@@ -4,20 +4,21 @@ class TestPlLocale < Test::Unit::TestCase
   def setup
     @phone_prefixes = %w{12 13 14 15 16 17 18 22 23 24 25 29 32 33 34 41 42 43 44 46 48 52 54 55 56 58 59 61 62 63 65 67 68 71 74 75 76 77 81 82 83 84 85 86 87 89 91 94 95}.sort
     @cell_prefixes = %w{50 51 53 57 60 66 69 72 73 78 79 88}.sort
-    @previous_locale = FactoryHelper::Config.locale
     FactoryHelper::Config.locale = :pl
   end
 
   def teardown
-    FactoryHelper::Config.locale = @previous_locale
+    FactoryHelper::Config.locale = nil
   end
 
   def test_pl_phone_number
+    #TODO: this 999 is probably causing the intermittent failures
     prefixes = (0..999).map { FactoryHelper::PhoneNumber.phone_number[0,2] }.uniq.sort
     assert_equal @phone_prefixes, prefixes
   end
 
   def test_pl_cell_phone
+    #TODO: this 999 is probably causing the intermittent failures
     prefixes = (0..999).map { FactoryHelper::PhoneNumber.cell_phone[0,2] }.uniq.sort
     assert_equal @cell_prefixes, prefixes
   end


### PR DESCRIPTION
- `pry` has come in handy twice already - thoughts on adding it permanently?
- the fix is to set the locale to `nil` in teardown rather than reset to original `:en`. Not sure yet what this means.

_At this stage, recommend adding note to README about incompatibility of FactoryHelper & Faker, and about the former being a drop-in replacement for the latter._
