### PR TITLE
Fix seed setter method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ FactoryHelper now supports seeding of its pseudo-random number generator
 (PRNG) to provide deterministic output of repeated method calls.
 
 ```ruby
-FactoryHelper::Config.seed = 42
+FactoryHelper::Config.set_seed 42
 FactoryHelper::Company.bs #=> "seize collaborative mindshare"
 FactoryHelper::Company.bs #=> "engage strategic platforms"
-FactoryHelper::Config.seed = 42
+FactoryHelper::Config.set_seed 42
 FactoryHelper::Company.bs #=> "seize collaborative mindshare"
 FactoryHelper::Company.bs #=> "engage strategic platforms"
 
-FactoryHelper::Config.seed = nil # seeds the PRNG
+FactoryHelper::Config.set_seed nil # seeds the PRNG
 FactoryHelper::Config.seed #=> 6263681755117030645311740483944653976248826274740079170131
 FactoryHelper::Company.bs #=> "cultivate viral synergies"
 ```

--- a/lib/factory-helper.rb
+++ b/lib/factory-helper.rb
@@ -29,7 +29,7 @@ module FactoryHelper
         @random.seed
       end
 
-      def seed= (seed)
+      def set_seed (seed)
         if seed
           @random= Random.new(seed)
         else
@@ -40,7 +40,7 @@ module FactoryHelper
     end
 
     self.locale= nil
-    self.seed= nil
+    self.set_seed nil
   end
 
   class Base

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe FactoryHelper::Config do
   describe 'PRNG' do
     specify '.seed= returns new seed' do
-      expect(FactoryHelper::Config.seed= nil).to eq FactoryHelper::Config.seed
+      expect(FactoryHelper::Config.set_seed nil).to eq FactoryHelper::Config.seed
     end
 
     specify '.random.seed' do
@@ -10,13 +10,13 @@ RSpec.describe FactoryHelper::Config do
 
     specify 'use Random for entropy' do
       expect(Random).to receive(:new_seed)
-      FactoryHelper::Config.seed= nil
+      FactoryHelper::Config.set_seed nil
     end
 
     #use two entropy sources because "Starting with Unicorn 3.6.1, we have builtin workarounds for Kernel#rand and OpenSSL::Random users, but applications may use other PRNGs."
     specify 'use Kernel.rand for entropy' do
       expect(Kernel).to receive(:rand)
-      FactoryHelper::Config.seed= nil
+      FactoryHelper::Config.set_seed nil
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FactoryHelper::Config do
   describe 'PRNG' do
-    specify '.seed= returns new seed' do
+    specify '.set_seed returns new seed' do
       expect(FactoryHelper::Config.set_seed nil).to eq FactoryHelper::Config.seed
     end
 

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -8,12 +8,12 @@ class TestDeterminism < Test::Unit::TestCase
   end
 
   def test_determinism
-    FactoryHelper::Config.seed= 42
+    FactoryHelper::Config.set_seed 42
     @all_methods.each_index do |index|
       store_result @all_methods[index]
     end
     @first_run.freeze
-    FactoryHelper::Config.seed= 42
+    FactoryHelper::Config.set_seed 42
     @all_methods.each_index do |index|
       assert deterministic_random? @first_run[index], @all_methods[index]
     end


### PR DESCRIPTION
Issue was that the `seed= (value)` always returns the `value`. It is ignoring the `return` statement. 
This is a feature of Ruby.

I renamed it to `set_seed` and all works well.
